### PR TITLE
Update README.md

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -9,24 +9,6 @@
 
 <div align="center">
 
-<a href="https://pypi.org/project/tavily-python/">
-  <img
-    src="https://img.shields.io/pypi/dm/tavily-python?style=for-the-badge&label=tavily-python&color=70a790&labelColor=0B0907"
-    alt="tavily-python downloads/month"
-  />
-</a>
-<a href="https://www.npmjs.com/package/tavily">
-  <img
-    src="https://img.shields.io/npm/dm/tavily?style=for-the-badge&label=tavily-js&color=70a790&labelColor=0B0907"
-    alt="tavily-js downloads/month"
-  />
-</a>
-<a href="https://www.npmjs.com/package/tavily-mcp">
-  <img
-    src="https://img.shields.io/npm/dm/tavily-mcp?style=for-the-badge&label=tavily-mcp&color=70a790&labelColor=0B0907"
-    alt="tavily-mcp downloads/month"
-  />
-</a>
 
 </div>
 


### PR DESCRIPTION
Removed download badges for tavily-python, tavily-js, and tavily-mcp from README.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes download badges from the profile README to simplify the header section.
> 
> - Deletes PyPI (`tavily-python`) and npm (`tavily`, `tavily-mcp`) monthly download badges from `profile/README.md`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ad6b6284e626b02462a01aab82ea4de0ce487d33. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->